### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) s
 
 Only ever use a read-only API key with this server. I wouldn't trust my code with your "money" and neither should you!
 
+<a href="https://glama.ai/mcp/servers/ydqbfrwdg4">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/ydqbfrwdg4/badge" alt="Bybit Server MCP server" />
+</a>
+
 ```shell
 Started integrated server
 Chatting with llama-3.2-11b-instruct:Q8_0 (Ctrl+C to exit)


### PR DESCRIPTION
This PR adds a badge for the [Bybit MCP Server](https://glama.ai/mcp/servers/ydqbfrwdg4) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ydqbfrwdg4">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/ydqbfrwdg4/badge" alt="Bybit Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.